### PR TITLE
Add priority tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Welcome to **MyNotes** 📓, your solution for effortless day-to-day task manage
 
 🗑️ **Delete Notes:** Completed a task? Simply delete the note associated with it.
 
+🏷️ **Priority Tags:** Assign a priority level (Low, Medium, High or Urgent) to each note and filter the list by these tags.
+
 📱 **Responsive Design:** Whether you're on your desktop, tablet, or smartphone, MyNotes provides a smooth and consistent user experience.
 
 🌈 **Modern Styling:** Enjoy a visually appealing design with carefully chosen colors, fonts, and layout.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,11 +7,13 @@ import CreateNote from "./pages/CreateNote";
 import EditNote from "./pages/EditNote";
 
 import { useState, useEffect } from "react";
+import { DEFAULT_TAG } from "./tags";
 
 function App() {
-  const [notes, setNotes] = useState(
-    JSON.parse(localStorage.getItem("notes")) || []
-  );
+  const [notes, setNotes] = useState(() => {
+    const saved = JSON.parse(localStorage.getItem("notes")) || [];
+    return saved.map((n) => ({ ...n, tag: n.tag || DEFAULT_TAG }));
+  });
   useEffect(() => {
     localStorage.setItem("notes", JSON.stringify(notes));
   }, [notes]);

--- a/src/components/NoteItem.jsx
+++ b/src/components/NoteItem.jsx
@@ -12,6 +12,7 @@ const NoteItem = ({ note }) => {
       <h4 className="text-[#FFF] lg:text-xl md:text-lg sm:text-sm text-xs">
         {note.title.length > 20 ? note.title.substr(0, 20) + "..." : note.title}
       </h4>
+      <span className="text-[10px] text-[#aaa]">{note.tag}</span>
       <p className="text-[rgba(255,255,255,0.50)] lg:text-[16px] md:text-[14px] sm:text-[12px] text-[10px]">{note.date}</p>
     </Link>
   );

--- a/src/components/useCreateDate.jsx
+++ b/src/components/useCreateDate.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-fallthrough */
-/* eslint-disable no-unused-vars */
 const useCreateDate = () => {
   const dateObj = new Date();
   const month = dateObj.getMonth();

--- a/src/pages/CreateNote.jsx
+++ b/src/pages/CreateNote.jsx
@@ -5,10 +5,12 @@ import { Link, useNavigate } from "react-router-dom";
 import { IoIosArrowBack } from "react-icons/io";
 import { v4 as uuid } from "uuid";
 import useCreateDate from "../components/useCreateDate";
+import { TAGS, DEFAULT_TAG } from "../tags";
 
 const CreateNote = ({ setNotes }) => {
   const [title, setTitle] = useState("");
   const [details, setDetails] = useState("");
+  const [tag, setTag] = useState(DEFAULT_TAG);
   const date = useCreateDate();
   const navigate = useNavigate();
 
@@ -21,6 +23,7 @@ const CreateNote = ({ setNotes }) => {
         title,
         details,
         date,
+        tag,
       };
       setNotes((prevNotes) => [note, ...prevNotes]);
       navigate("/");
@@ -47,6 +50,17 @@ const CreateNote = ({ setNotes }) => {
         onSubmit={handleSubmit}
         className="create_note_form w-full gap-3 flex mt-3 flex-col items-center justify-center "
       >
+        <select
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          className="w-full p-2 text-white bg-[#ffffff03] border-[1px] border-[#ffffff1a] border-solid outline-none"
+        >
+          {TAGS.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
         <input
           type="text"
           placeholder="Title"

--- a/src/pages/EditNote.jsx
+++ b/src/pages/EditNote.jsx
@@ -5,12 +5,14 @@ import { Link, useParams, useNavigate } from "react-router-dom";
 import { IoIosArrowBack } from "react-icons/io";
 import { RiDeleteBin6Line } from "react-icons/ri";
 import useCreateDate from "../components/useCreateDate";
+import { TAGS, DEFAULT_TAG } from "../tags";
 
 const EditNote = ({ notes, setNotes }) => {
   const { id } = useParams();
   const note = notes.find((item) => item.id == id);
   const [title, setTitle] = useState(note.title);
   const [details, setDetails] = useState(note.details);
+  const [tag, setTag] = useState(note.tag || DEFAULT_TAG);
   const date = useCreateDate();
   const navigate = useNavigate();
 
@@ -18,7 +20,7 @@ const EditNote = ({ notes, setNotes }) => {
     e.preventDefault();
 
     if (title && details) {
-      const newNote = { ...note, title, details, date };
+      const newNote = { ...note, title, details, date, tag };
 
       const newNotes = notes.map((item) => {
         if (item.id == id) {
@@ -69,6 +71,17 @@ const EditNote = ({ notes, setNotes }) => {
         onSubmit={handleForm}
         className="create_note_form w-full gap-3 flex mt-3 flex-col items-center justify-center"
       >
+        <select
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          className="w-full p-2 text-white bg-[#ffffff03] border-[1px] border-[#ffffff1a] border-solid outline-none"
+        >
+          {TAGS.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
         <input
           type="text"
           // placeholder="Title"

--- a/src/pages/Notes.jsx
+++ b/src/pages/Notes.jsx
@@ -6,23 +6,25 @@ import { CiSearch } from "react-icons/ci";
 import { MdClose } from "react-icons/md";
 import { BsPlusLg } from "react-icons/bs";
 import NoteItem from "../components/NoteItem.jsx";
+import { TAGS } from "../tags";
 
 const Notes = ({ notes }) => {
   const [showSearch, setShowSearch] = useState(false);
   const [text, setText] = useState("");
+  const [tagFilter, setTagFilter] = useState("all");
   const [filteredNotes, setFilteredNotes] = useState(notes);
 
   const handleSearch = () => {
     setFilteredNotes(
       notes.filter((note) => {
-        if (note.title.toLowerCase().match(text.toLowerCase())) {
-          return note;
-        }
+        const matchesText = note.title.toLowerCase().includes(text.toLowerCase());
+        const matchesTag = tagFilter === "all" || note.tag === tagFilter;
+        return matchesText && matchesTag;
       })
     );
   };
 
-  useEffect(handleSearch, [text]);
+  useEffect(handleSearch, [text, tagFilter, notes]);
 
   return (
     <section className="lg:w-[80%] lg:p-10 h-[screen-4%] lg:gap-4 md:w-[90%] md:h-[90%] md:p-4 md:gap-3 flex justify-between items-center flex-col bg-[#171616] rounded-[12px] sm:w-[90%] sm:h-[90%] sm:p-3 sm:gap-3 w-full h-full p-2 gap-3">
@@ -58,6 +60,22 @@ const Notes = ({ notes }) => {
           )}
         </button>
       </header>
+
+      <select
+        value={tagFilter}
+        onChange={(e) => {
+          setTagFilter(e.target.value);
+          handleSearch();
+        }}
+        className="w-full p-2 bg-[#1e1c1c] text-white border border-[#ffffff1a] outline-none"
+      >
+        <option value="all">All</option>
+        {TAGS.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
 
       <div className="notes_container grid lg:grid-cols-4 md:grid-cols-3 md:mt-4 sm:grid-cols-2 xs:grid-col-1 flex-1 overflow-auto w-full gap-4 sm:mt-3 p-2 grid-cols-2">
         {filteredNotes.length == 0 && (

--- a/src/tags.js
+++ b/src/tags.js
@@ -1,0 +1,2 @@
+export const TAGS = ["Low", "Medium", "High", "Urgent"];
+export const DEFAULT_TAG = TAGS[0];


### PR DESCRIPTION
## Summary
- define available note tags
- let users pick tags when creating or editing a note
- display note tags in the list
- filter notes by tag
- migrate existing notes to use a default tag
- document the priority feature in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68405013e25c8324a6b1d4e75bd3dc2d